### PR TITLE
Update and be explicit about order of operations when multiple flags are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ Flags:
   -E, --exclude             Exclude files matching these patterns (e.g. '*.test.js')
 ```
 
+### Filter Priority
+When multiple filters are active, they are applied in the following order:
+
+1. .gitignore rules (unless --include-gitignore is set)
+2. Directory exclusions
+3. .git directory (unless --include-git is set)
+4. Binary files (unless --include-bin is set)
+5. Explicit exclude patterns (-E/--exclude)
+6. Explicit include patterns (-I/--include)
+
+A file must pass all applicable filters to be included in the output. If no `--include` patterns are specified, all files that pass the other filters will be included. The `--include` flag acts as an additional filter, only taking effect when explicitly set.
+
 ## License
 MIT License
 

--- a/cmd/flatten/filter.go
+++ b/cmd/flatten/filter.go
@@ -75,13 +75,14 @@ func (f *Filter) ShouldInclude(info os.FileInfo, path string) bool {
 	}
 
 	if !info.IsDir() {
+		if f.matchesAnyPattern(path, f.excludePatterns) {
+			return false
+		}
+
 		if len(f.includePatterns) > 0 {
 			if !f.matchesAnyPattern(path, f.includePatterns) {
 				return false
 			}
-		}
-		if f.matchesAnyPattern(path, f.excludePatterns) {
-			return false
 		}
 	}
 


### PR DESCRIPTION
This follows my preference for the order. I want git ignore to always be respected until I set a flag. `--include *xxx*` keeps hitting files in `node_modules`.  

Your preference may differ :smiley: 